### PR TITLE
fix: change Jira client connection to use api_token

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 | Step               | Description                                                                                                                                   |
 |--------------------|----------------------------------------------------------------------------|
-| `verifyConditions` | Validate the config options and check for a `JIRA_AUTH` in the environment |
+| `verifyConditions` | Validate the config options and checks for `JIRA_EMAIL` and `JIRA_TOKEN` in the environment |
 | `sucess`           | Find all tickets from commits and add them to a new release on JIRA        |
 
 ## Install

--- a/lib/jira.ts
+++ b/lib/jira.ts
@@ -6,7 +6,8 @@ export function makeClient(config: PluginConfig, context: PluginContext): JiraCl
   return new JiraClient({
     host: config.jiraHost,
     basic_auth: {
-      base64: context.env.JIRA_AUTH,
+      email: context.env.JIRA_EMAIL,
+      api_token: context.env.JIRA_TOKEN,
     },
   });
 }

--- a/lib/verifyConditions.ts
+++ b/lib/verifyConditions.ts
@@ -46,8 +46,11 @@ export async function verifyConditions(config: PluginConfig, context: PluginCont
     throw new SemanticReleaseError(`config.networkConcurrency must be an number greater than 0`);
   }
 
-  if (!context.env.JIRA_AUTH) {
-    throw new SemanticReleaseError(`JIRA_AUTH must be a string`);
+  if (!context.env.JIRA_EMAIL) {
+    throw new SemanticReleaseError(`JIRA_EMAIL must be a string`);
+  }
+  if (!context.env.JIRA_TOKEN) {
+    throw new SemanticReleaseError(`JIRA_TOKEN must be a string`);
   }
   const jira = makeClient(config, context);
   await jira.project.getProject({ projectIdOrKey: config.projectId });

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -6,11 +6,12 @@ import { context, pluginConfig } from './fakedata';
 
 const itif = condition => condition ? it : it.skip;
 
-const runIntegration = () => { return process.env.JIRA_AUTH && process.env.JIRA_HOST && process.env.JIRA_PROJECT_ID; };
+const runIntegration = () => { return process.env.JIRA_EMAIL && process.env.JIRA_TOKEN && process.env.JIRA_HOST && process.env.JIRA_PROJECT_ID; };
 
 describe('integration tests', () => {
   beforeAll(() => {
-    context.env.JIRA_AUTH = process.env.JIRA_AUTH as string;
+    context.env.JIRA_EMAIL = process.env.JIRA_EMAIL as string;
+    context.env.JIRA_TOKEN = process.env.JIRA_TOKEN as string;
     pluginConfig.projectId = Number(process.env.JIRA_PROJECT_ID);
     pluginConfig.jiraHost = process.env.JIRA_HOST;
     pluginConfig.dryRun = false;


### PR DESCRIPTION
Following the recent Jira deprecation of the basic auth connection: https://confluence.atlassian.com/cloud/deprecation-of-basic-authentication-with-passwords-for-jira-and-confluence-apis-972355348.html

The current release throws the following:
{code:json}
{"statusCode":401,"body":"Basic authentication with passwords is deprecated. For more information, see: https://confluence.atlassian.com/cloud/deprecation-of-basic-authentication-with-passwords-for-jira-and-confluence-apis-972355348.html"}
{code}

Changes:
- switch `jira-connector` to use email + api_token auth (https://www.npmjs.com/package/jira-connector#basic-authentication-with-api-token)
- configure JIRA_EMAIL & JIRA_TOKEN as required env vars